### PR TITLE
Bugfix -> workaround instructions to install HMLR components - install older version v1.1.0

### DIFF
--- a/src/get-started/prototyping/index.md
+++ b/src/get-started/prototyping/index.md
@@ -22,7 +22,7 @@ To make prototypes use the link below to navigate to the GOV.UK setup guide.
 Using the latest prototype kit as a base, install the HM Land Registry frontend styles and templates:
 
 ```sh
-npm install @hmlr/frontend
+npm install @hmlr/frontend@v1.1.0
 ```
 
 You can now import and use the HM Land Registry components in your prototype just as you can with the GOV.UK ones.

--- a/src/get-started/prototyping/index.md
+++ b/src/get-started/prototyping/index.md
@@ -7,6 +7,8 @@ order: 1
 description: This guide explains how to create prototypes using the GOV.UK Design System and GOV.UK Prototype Kit
 ---
 
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
 The GOV.UK guide explains how to create prototypes using the GOV.UK Design System and GOV.UK Prototype Kit.
 
 ## Before you start
@@ -28,3 +30,10 @@ npm install @hmlr/frontend@v1.1.0
 You can now import and use the HM Land Registry components in your prototype just as you can with the GOV.UK ones.
 
 Example code can be found in the [components](/components/) section.
+
+{{ govukInsetText({
+  classes: "app-table--constrained",
+  html: 'These instructions will install an older version (v1.1.0) of the HM Land Registry components, as a bug exists when using the latest version (v1.3.0) with the latest Gov prototype kit (v13).   <a href="/get-in-touch/">Contact us if you need help using the components</a>.'
+}) }}
+
+


### PR DESCRIPTION
instructions to install v1.1.0 of the HMLR components - rather than it install the latest (broken)

inset text block to tell people they are installing an older version, there is a bug with the latest version, and contact the team for any help

Testing: I've tested the new (workaround) installation instructions on this page, as though i was a creating a prototype for the first time.  Following the Gov prototyping kit instructions, then our instructions.