### PR TITLE
Accessibility statement amends

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13026,38 +13026,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-1.3.0.tgz",
       "integrity": "sha512-xPLahSmi5cp0id46BHffsrWDpU1z0zt2Hl1B8Qn/GQhOv9UGE2u/qQQHwdg+H/Nk3Emx5JYN4fKbmc3XvQA2Lw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimatch": "0.3.0"
-      },
-      "engines": {
-        "node": ">=0.6.6"
-      }
-    },
-    "node_modules/recursive-readdir/node_modules/lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ==",
-      "license": "ISC"
-    },
-    "node_modules/recursive-readdir/node_modules/minimatch": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
-      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
-      "license": "MIT",
-      "dependencies": {
-        "lru-cache": "2",
-        "sigmund": "~1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/recursive-readdir": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-1.3.0.tgz",
-      "integrity": "sha512-xPLahSmi5cp0id46BHffsrWDpU1z0zt2Hl1B8Qn/GQhOv9UGE2u/qQQHwdg+H/Nk3Emx5JYN4fKbmc3XvQA2Lw==",
       "dependencies": {
         "minimatch": "0.3.0"
       },

--- a/src/accessibility-statement.md.njk
+++ b/src/accessibility-statement.md.njk
@@ -24,13 +24,13 @@ We've also made the website text as simple as possible to understand. We  only u
 
 We know some parts of this website are not fully accessible:
 
-- with an increased text size, some text 'overflows' which means that words or sentences may cut off and unreadable
+- with an increased text size, some text 'overflows' which means that words or sentences may be cut off and unreadable
 - tabbing on some pages may not be in the correct order
-- when tabbing focus may be lost.
+- when tabbing focus, may be lost
 
 ### Feedback and contact information
 
-The HM Land Registry Design System team is always looking to improve the accessibility of this website. If you find any problems that are not listed on this page or think this website is not meeting accessibility requirements, email the HM Land Registry Design System team at hmlr-design-system-support@landregistry.gov.uk
+The HM Land Registry Design System team is always looking to improve the accessibility of this website. If you find any problems that are not listed on this page or think this website is not meeting accessibility requirements, email the HM Land Registry Design System team at hmlr-design-system-support@landregistry.gov.uk.
 
 The HM Land Registry Design System team will review your request and get back to you in 2 working days.
 
@@ -54,26 +54,21 @@ The content listed below is non-accessible for the following reasons.
 
 ### Non-compliance with the accessibility regulations
 
-When browser text size is adjusted to 200% or 'very large' text 'overflows' which means that some words or sentences may be cut off and unreadable.
+When browser text size is adjusted to 200% or 'very large' text 'overflows' which means that some words or sentences may be cut off and unreadable. This fails WCAG 2.2 Success criterion 1.4.10 (Reflow).
 
-<b>This fails WCAG 2.2 Success criterion 1.4.10 (Reflow).</b>
+Some of the tabbing on the components pages is in the incorrect order. This fails WCAG 2.2 Success criterion 2.4.3 (Focus order).
 
-Some of the tabbing on the components pages is in the incorrect order.
+When tabbing, the focus is also hidden on some pages. This fails WCAG 2.2 Success criterion 2.4.12 (Focus not obscured (enhanced)).<br></br>
 
-<b>This fails WCAG 2.2 Success criterion 2.4.3 (Focus order).
-
-When tabbing, the focus is also hidden on some pages.
-
-<b>This fails WCAG 2.2 Success criterion 2.4.12 (Focus not obscured (enhanced)).
 
 ## What we're doing to improve accessibility
 
-We plan to investigate and resolve the non-accessible content by December 2024.
+We plan to investigate and resolve the non-accessible content by 31st March 2025.
 
 ## Preparation of this accessibility statement
 
 This statement was prepared on 2 August 2023. It was last reviewed on 3 September 2024.
 
-This website was last tested on November 2023 against the WCAG 2.2 AA standard.
+This website was last tested on 2 November 2023 against the WCAG 2.2 AA standard.
 
 The test was carried out by HM Land Registry. All the pages were tested using manual and automated testing tools by our website team.

--- a/views/layouts/layout-contents-left.njk
+++ b/views/layouts/layout-contents-left.njk
@@ -5,27 +5,31 @@
 
   <div class="govuk-grid-column-one-quarter-from-desktop contents-list-container">
             <nav data-module="ga4-link-tracker" aria-label="Contents" class="gem-c-contents-list" role="navigation" data-ga4-link-tracker-module-started="true">
-      <p class="govuk-body"> Contents</p>
+      <p class="govuk-body-s"> Contents</p>
                 <ul class="govuk-list">
           <li>
             <span aria-hidden="true"></span>
-            <a class="govuk-body gem-c-contents-list__link govuk-link govuk-link--no-underline" data-ga4-link="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;section&quot;:&quot;Contents&quot;,&quot;type&quot;:&quot;contents list&quot;,&quot;index_total&quot;:5,&quot;index_link&quot;:1}" href="#accessibility-statement-for-website-name">Accessibility statement for the HM Land Registry Design System</a>
+            <a class="govuk-body-s gem-c-contents-list__link govuk-link govuk-link--no-underline" data-ga4-link="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;section&quot;:&quot;Contents&quot;,&quot;type&quot;:&quot;contents list&quot;,&quot;index_total&quot;:5,&quot;index_link&quot;:1}" href="#accessibility-statement-for-website-name">Accessibility statement for the HM Land Registry Design System</a>
           </li>
+
           <li>
             <span aria-hidden="true"></span>
-            <a class="govuk-body gem-c-contents-list__link govuk-link govuk-link--no-underline" data-ga4-link="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;section&quot;:&quot;Contents&quot;,&quot;type&quot;:&quot;contents list&quot;,&quot;index_total&quot;:5,&quot;index_link&quot;:2}" href="#technical-information-about-this-websites-accessibility">Technical information about this website’s accessibility</a>
+            <a class="govuk-body-s gem-c-contents-list__link govuk-link govuk-link--no-underline" data-ga4-link="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;section&quot;:&quot;Contents&quot;,&quot;type&quot;:&quot;contents list&quot;,&quot;index_total&quot;:5,&quot;index_link&quot;:2}" href="#technical-information-about-this-websites-accessibility">Technical information about this website’s accessibility</a>
           </li>
+
           <li>
             <span aria-hidden="true"></span>
-            <a class="govuk-body gem-c-contents-list__link govuk-link govuk-link--no-underline" data-ga4-link="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;section&quot;:&quot;Contents&quot;,&quot;type&quot;:&quot;contents list&quot;,&quot;index_total&quot;:5,&quot;index_link&quot;:3}" href="#non-accessible-content">Non-accessible content</a>
+            <a class="govuk-body-s gem-c-contents-list__link govuk-link govuk-link--no-underline" data-ga4-link="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;section&quot;:&quot;Contents&quot;,&quot;type&quot;:&quot;contents list&quot;,&quot;index_total&quot;:5,&quot;index_link&quot;:3}" href="#non-accessible-content">Non-accessible content</a>
           </li>
+
           <li>
             <span aria-hidden="true"></span>
-            <a class="govuk-body gem-c-contents-list__link govuk-link govuk-link--no-underline" data-ga4-link="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;section&quot;:&quot;Contents&quot;,&quot;type&quot;:&quot;contents list&quot;,&quot;index_total&quot;:5,&quot;index_link&quot;:4}" href="#what-were-doing-to-improve-accessibility">What we’re doing to improve accessibility</a>
+            <a class="govuk-body-s gem-c-contents-list__link govuk-link govuk-link--no-underline" data-ga4-link="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;section&quot;:&quot;Contents&quot;,&quot;type&quot;:&quot;contents list&quot;,&quot;index_total&quot;:5,&quot;index_link&quot;:4}" href="#what-were-doing-to-improve-accessibility">What we’re doing to improve accessibility</a>
           </li>
+          
           <li>
             <span aria-hidden="true"></span>
-            <a class="govuk-body gem-c-contents-list__link govuk-link govuk-link--no-underline" data-ga4-link="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;section&quot;:&quot;Contents&quot;,&quot;type&quot;:&quot;contents list&quot;,&quot;index_total&quot;:5,&quot;index_link&quot;:5}" href="#preparation-of-this-accessibility-statement">Preparation of this accessibility statement</a>
+            <a class="govuk-body-s gem-c-contents-list__link govuk-link govuk-link--no-underline" data-ga4-link="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;section&quot;:&quot;Contents&quot;,&quot;type&quot;:&quot;contents list&quot;,&quot;index_total&quot;:5,&quot;index_link&quot;:5}" href="#preparation-of-this-accessibility-statement">Preparation of this accessibility statement</a>
           </li>
       </ul>
   </nav>


### PR DESCRIPTION
Updates to make

Reduce the size of the contents body (• review side navigation: size of font, spacing between contents is different to patterns used throughout the system - what do we want to do about this. Accessibility compliance.)

How accessible this website is section:

• review first bullet point content- add 'be' after 'may'

• remove '.' on last bullet point of first set of bullet points

• add comma after 'focus'

Feedback and contact info section:

• add fullstop at end of para (after email address)

• spacing before paragraph: 'What we're doing to improve accessibility'

• remove bold from failure sentences and put related sentence for description and failures in same paragraphs

• amend date to 31st March 2025 (see Adams message re: Convo with Josie Davey)