### PR TITLE
Hiding maps page from Guidance index page

### DIFF
--- a/src/guidance/maps/index.md.njk
+++ b/src/guidance/maps/index.md.njk
@@ -1,10 +1,11 @@
 ---
 title: Maps
+status: Draft
 description: Guidance to help you use maps within your service
 section: Guidance
-theme: 
+theme:
 layout: layout-pane.njk
-show_page_nav: true
+show_page_nav: false
 order: 2
 ---
 
@@ -46,7 +47,7 @@ Map alternatives could include:
 - providing data in other formats, such as geoJSON
 - a search and filter function
 
-### Map accessibility 
+### Map accessibility
 Maps and mapping services do not fall under the accessibility regulations.
 
 Maps can contain accessibility issues and usability can be complex. You should make mapping features as accessible and usable as possible.
@@ -56,7 +57,7 @@ Ways to make a map more usable and accessible include:
 - placing map controls outside of the map
 - use vector map tiles to allow for layering and styling of map features
 
-### Ordering pages, elements and map options 
+### Ordering pages, elements and map options
 
 Organise the order of pages in the service and the order of elements on the page, for example:
 - placing a postcode search first
@@ -155,7 +156,7 @@ Learn from other Government departments maps guidance. View:
 
 [Ordnance Survey Labs](https://labs.os.uk/pages/index.html) contains tools and information for using maps.
 
-The [GeoDataViz Toolkit](https://github.com/OrdnanceSurvey/GeoDataViz-Toolkit) contains sections on: 
+The [GeoDataViz Toolkit](https://github.com/OrdnanceSurvey/GeoDataViz-Toolkit) contains sections on:
 - Using the right basemap
 - Cartographic design principles
 - Using colours
@@ -164,6 +165,4 @@ The [GeoDataViz Toolkit](https://github.com/OrdnanceSurvey/GeoDataViz-Toolkit) c
 
 ## Help us improve maps and this guidance
 
-If you have feedback on how we can improve this guide, email [hmlr-design-system-support@landregistry.gov.uk](mailto:hmlr-design-system-support@landregistry.gov.uk). 
-
-
+If you have feedback on how we can improve this guide, email [hmlr-design-system-support@landregistry.gov.uk](mailto:hmlr-design-system-support@landregistry.gov.uk).


### PR DESCRIPTION
Added 'status: Draft' to the Maps guidance page. This also added 'draft' tag to the page when it is viewed (via search or URL)